### PR TITLE
Civic: Demonstrate how to reduce the frequency of chain polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "firebase-test-env",
       "version": "0.1.0",
       "dependencies": {
-        "@civic/ethereum-gateway-react": "v1.4.1-beta.2",
+        "@civic/ethereum-gateway-react": "1.4.5",
         "@privy-io/react-auth": "1.92.3",
         "dotenv": "^16.4.5",
         "ethers": "^6.11.1",
@@ -37,6 +37,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -50,6 +51,7 @@
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -60,9 +62,10 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.2.tgz",
-      "integrity": "sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -72,6 +75,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -102,6 +106,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -114,18 +119,20 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.26.3",
+        "@babel/types": "^7.26.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -138,6 +145,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
       "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -149,6 +157,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
       "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.25.9",
@@ -165,6 +174,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
@@ -174,6 +184,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "peer": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -183,6 +194,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
       "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -203,6 +215,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -211,6 +224,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
       "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -223,6 +237,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
       "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -235,6 +250,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
       "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -252,6 +268,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
       "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -263,6 +280,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
       "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -271,6 +289,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
       "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -287,6 +306,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
       "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -299,6 +319,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
       "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -307,6 +328,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -315,6 +337,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
       "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -324,6 +347,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
       "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
@@ -334,11 +358,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -352,6 +377,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
       "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -369,6 +395,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -383,6 +410,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -408,6 +436,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
       "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
         "@babel/parser": "^7.25.9",
@@ -418,15 +447,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.3.tgz",
+      "integrity": "sha512-yTmc8J+Sj8yLzwr4PD5Xb/WF3bOYu2C2OoSZPzbuqRm4n98XirsbzaX+GloeO376UnSYIYJ4NCanwV5/ugZkwA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.3",
+        "@babel/parser": "^7.26.3",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/types": "^7.26.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -438,14 +468,16 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -455,12 +487,12 @@
       }
     },
     "node_modules/@civic/ethereum-gateway-chain-client": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@civic/ethereum-gateway-chain-client/-/ethereum-gateway-chain-client-0.0.4.tgz",
-      "integrity": "sha512-pso+Y8inR6/2C7u98AY72ynPLyVG9bZVT1mmn2IdQLnuSCVDOj1rHPeY6gwZmmw2d9Q/7eaivAPUn2KPGUfmRA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@civic/ethereum-gateway-chain-client/-/ethereum-gateway-chain-client-0.0.6.tgz",
+      "integrity": "sha512-2ZezqwgYzwU449MU/phgL9s2peCqFgEPMa57Ky3/vt6lt/JbfnvxbA1HyssL/GgeGzqYYSMPDSpYHSmuR0ePmQ==",
       "dependencies": {
-        "@civic/gateway-client-core": "^1.0.7",
-        "@identity.com/prove-ethereum-wallet": "1.1.1",
+        "@civic/gateway-client-core": "1.1.5",
+        "@civic/prove-ethereum-wallet": "1.1.1",
         "ethers": "^6.12.1",
         "prop-types": "^15.8.1",
         "ramda": "^0.30.0"
@@ -470,20 +502,21 @@
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@civic/ethereum-gateway-react": {
-      "version": "1.4.1-beta.2",
-      "resolved": "https://registry.npmjs.org/@civic/ethereum-gateway-react/-/ethereum-gateway-react-1.4.1-beta.2.tgz",
-      "integrity": "sha512-lj3VicWqCidTa3LCasvZb20gQJV+Ol8FUwfJYIzd6m9jjGDdZCxsN1/uELq3CONIrgBNI4AJkXStYYK6ihLEwQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@civic/ethereum-gateway-react/-/ethereum-gateway-react-1.4.5.tgz",
+      "integrity": "sha512-IcOLKmy98SbJei4D+cg+3UO/46JYIhctlaBy2+HYcxIm0oHsXzvqKcavoT2NZBipi3KOVhIKSGVjCI6MAkhCLQ==",
       "dependencies": {
-        "@civic/ethereum-gateway-chain-client": "0.0.4",
-        "@civic/gateway-client-core": "1.1.2-beta.0",
-        "@civic/gateway-client-react": "1.2.2-beta.0",
-        "@identity.com/prove-ethereum-wallet": "1.1.1",
+        "@civic/ethereum-gateway-chain-client": "0.0.6",
+        "@civic/gateway-client-core": "1.1.5",
+        "@civic/gateway-client-react": "1.2.4",
+        "@civic/prove-ethereum-wallet": "1.1.1",
         "ethers": "^6.12.1",
         "prop-types": "^15.8.1",
         "ramda": "^0.29.0"
@@ -493,41 +526,11 @@
         "react-dom": "^18.2.0"
       }
     },
-    "node_modules/@civic/ethereum-gateway-react/node_modules/@civic/gateway-client-core": {
-      "version": "1.1.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@civic/gateway-client-core/-/gateway-client-core-1.1.2-beta.0.tgz",
-      "integrity": "sha512-BVJ9KNdsH1N2ijEDlGtEk9JksE7iIDb+vnYD72PN5xh0f9H0dFBfW+0IZ5n1Os+PwnNsd1KSkUV+LisWbMlt/A==",
-      "dependencies": {
-        "fetch-retry": "^6.0.0",
-        "immer": "^10.0.4",
-        "isomorphic-fetch": "^3.0.0",
-        "ramda": "^0.30.0",
-        "uuid": "^9.0.1",
-        "zustand": "^4.5.2",
-        "zustand-computed-state": "^0.1.3"
-      },
-      "peerDependencies": {
-        "zustand": "^4.5.2"
-      }
-    },
-    "node_modules/@civic/ethereum-gateway-react/node_modules/@civic/gateway-client-core/node_modules/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@civic/ethereum-gateway-react/node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag=="
-    },
     "node_modules/@civic/gateway-client-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@civic/gateway-client-core/-/gateway-client-core-1.1.0.tgz",
-      "integrity": "sha512-KwH0wYAl94Etht/RTnai8f0q9hgwEMPAe559PyIHuf6kBM8JG11XY4bEIblUVEeZKSplBqcJ4v9+vAXhKSI4LQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@civic/gateway-client-core/-/gateway-client-core-1.1.5.tgz",
+      "integrity": "sha512-85mytGAcLGW0TqBS+aqt3+0kL5Hr+riVUapEQQYCP2I/+9F60crwgG0Tz9nP+yIWmDBQSBCZ59z54GVGzK3qUQ==",
+      "license": "MIT",
       "dependencies": {
         "fetch-retry": "^6.0.0",
         "immer": "^10.0.4",
@@ -544,23 +547,25 @@
     "node_modules/@civic/gateway-client-core/node_modules/fetch-retry": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag=="
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/@civic/gateway-client-core/node_modules/ramda": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/@civic/gateway-client-react": {
-      "version": "1.2.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@civic/gateway-client-react/-/gateway-client-react-1.2.2-beta.0.tgz",
-      "integrity": "sha512-BkxLV6rG/hGhEQCmDH0d/f9DV+WdJ33Oix/sn1Jd+nR5ceTH/s72+CEvR0wSRoUh4kQh+DfXLa9/bKsy4LQPdw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@civic/gateway-client-react/-/gateway-client-react-1.2.4.tgz",
+      "integrity": "sha512-cl8Ff7Ax1svpge2jHLS6CRrgWjc6zcxEk8qrkS0ihX7AdjLGAPw70q/02nrubyC9N0is+gxo/TTU0D2E8yuBOA==",
       "dependencies": {
-        "@civic/gateway-client-core": "1.1.2-beta.0",
+        "@civic/gateway-client-core": "1.1.3",
         "@testing-library/react-hooks": "^8.0.1",
         "fetch-retry": "^5.0.6",
         "iframe-resizer-react": "^1.0.8",
@@ -575,9 +580,10 @@
       }
     },
     "node_modules/@civic/gateway-client-react/node_modules/@civic/gateway-client-core": {
-      "version": "1.1.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@civic/gateway-client-core/-/gateway-client-core-1.1.2-beta.0.tgz",
-      "integrity": "sha512-BVJ9KNdsH1N2ijEDlGtEk9JksE7iIDb+vnYD72PN5xh0f9H0dFBfW+0IZ5n1Os+PwnNsd1KSkUV+LisWbMlt/A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@civic/gateway-client-core/-/gateway-client-core-1.1.3.tgz",
+      "integrity": "sha512-cXxj64Bhe4ZrtAImekPlFT9cscdaytMlmzREfnitt4QfqezN7ZTGI/QQW3XNkHuHoS5/+zyFvBDXlR5HIjU+8w==",
+      "license": "MIT",
       "dependencies": {
         "fetch-retry": "^6.0.0",
         "immer": "^10.0.4",
@@ -594,12 +600,14 @@
     "node_modules/@civic/gateway-client-react/node_modules/@civic/gateway-client-core/node_modules/fetch-retry": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag=="
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/@civic/gateway-client-react/node_modules/@civic/gateway-client-core/node_modules/ramda": {
       "version": "0.30.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
       "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -608,12 +616,14 @@
     "node_modules/@civic/gateway-client-react/node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@civic/gateway-client-react/node_modules/@testing-library/react-hooks": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
       "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "react-error-boundary": "^3.1.0"
@@ -643,6 +653,7 @@
       "version": "17.0.83",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
       "integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -655,6 +666,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
@@ -662,6 +674,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -670,6 +683,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
       "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ramda"
@@ -679,6 +693,7 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -708,11 +723,74 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@civic/prove-ethereum-wallet": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@civic/prove-ethereum-wallet/-/prove-ethereum-wallet-1.1.1.tgz",
+      "integrity": "sha512-HWLDC0K/VsSF8lDFG6XoQSS+3obOD4iWI08wg2S/ZF4CSA9IU8dAnbJS4YjW3bFQUS+Pxfaa44HQDkxt9YLlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.5.0",
+        "buffer": "^6.0.3",
+        "ethers": "^5.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@civic/prove-ethereum-wallet/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
@@ -744,7 +822,8 @@
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
@@ -1639,66 +1718,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
-    },
-    "node_modules/@identity.com/prove-ethereum-wallet": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@identity.com/prove-ethereum-wallet/-/prove-ethereum-wallet-1.1.1.tgz",
-      "integrity": "sha512-E0mqT6AfsDGGOJT4090OuHZDFJCVTH/pgNBFAba0RpJc1foD88LmkW53r7NEPnHz4qE6QnwSNIrJpVggT/dMhA==",
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "buffer": "^6.0.3",
-        "ethers": "^5.5.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@identity.com/prove-ethereum-wallet/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4253,6 +4272,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
       "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-module-imports": "^7.22.5",
@@ -4404,6 +4424,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
@@ -4733,6 +4754,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/cookie-es": {
@@ -5067,9 +5089,10 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.66",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.66.tgz",
-      "integrity": "sha512-pI2QF6+i+zjPbqRzJwkMvtvkdI7MjVbSh2g8dlMguDJIXEPw+kwasS1Jl+YGPEBfGVxsVgGUratAKymPdPo2vQ==",
+      "version": "1.5.70",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.70.tgz",
+      "integrity": "sha512-P6FPqAWIZrC3sHDAwBitJBs7N7IF58m39XVny7DFseQXK2eiMn7nNQizFf63mWDDUnFvaqsM8FI0+ZZfLkdUGA==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/elliptic": {
@@ -5343,6 +5366,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -6388,6 +6412,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -6682,6 +6707,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -6757,6 +6783,7 @@
       "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
       "integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       },
@@ -6769,6 +6796,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/iframe-resizer-react/-/iframe-resizer-react-1.1.1.tgz",
       "integrity": "sha512-s0EUUekv58FGbuWBanSCVsEKmmyBdWmdwQ8qx8g04jlNlCR7pNuDz7fw7zo5T5sdssl6yRMDl97NBdwD1gfDyQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "iframe-resizer": "^4.4.4",
@@ -6801,6 +6829,7 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7362,6 +7391,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
       "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -7558,6 +7588,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -8158,6 +8189,7 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/normalize-path": {
@@ -8997,6 +9029,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
       "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -10470,6 +10503,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
@@ -10706,6 +10740,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -10941,7 +10976,8 @@
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -11195,6 +11231,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/yaml": {
@@ -11329,6 +11366,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
       "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.2"
       },
@@ -11356,6 +11394,7 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/zustand-computed-state/-/zustand-computed-state-0.1.8.tgz",
       "integrity": "sha512-df6XMpo7ZhFRvs3gXENTbZebhAuwg37S/Bk0G94z4QfwzmoB3z12jdmJBoItxDOm7adjOkjk1kxyPf/WZiLQvw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -11367,6 +11406,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
       "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@civic/ethereum-gateway-react": "v1.4.1-beta.2",
+    "@civic/ethereum-gateway-react": "^1.4.5",
     "@privy-io/react-auth": "1.92.3",
     "dotenv": "^16.4.5",
     "ethers": "^6.11.1",

--- a/src/components/civicContent.tsx
+++ b/src/components/civicContent.tsx
@@ -71,7 +71,9 @@ export const CivicProvider = ({ children }: { children?: React.ReactNode }) => {
       wallet={wallet}
       gatekeeperNetwork={gatekeeperNetwork}
       wrapper={CustomWrapper}
-      options={{ autoShowModal: false, disableAutoRestartOnValidationFailure: true }}
+      // Set chainPollingIntervalMs to choose how frequently Civic polls the chain for pass updates.
+      // Default is 5 seconds.
+      options={{ autoShowModal: false, disableAutoRestartOnValidationFailure: true, chainPollingIntervalMs: 10000 }}
     >
       {children}
     </GatewayProvider>


### PR DESCRIPTION
Civic: Demonstrate how to reduce the frequency of chain polling with the latest version 1.4.5 of the Civic Ethereum SDK.
The polling now defaults to every 5 seconds, but it can be reduced further by passing the `chainPollingIntervalMs` property to the Civic `<GatewayProvider>`